### PR TITLE
Allow firmware loading from ODM partition

### DIFF
--- a/init/devices.cpp
+++ b/init/devices.cpp
@@ -58,7 +58,8 @@
 #define SYSFS_PREFIX    "/sys"
 static const char *firmware_dirs[] = { "/etc/firmware",
                                        "/vendor/firmware",
-                                       "/firmware/image" };
+                                       "/firmware/image",
+                                       "/odm/firmware" };
 
 extern struct selabel_handle *sehandle;
 


### PR DESCRIPTION
ODM partition may contain firmware and we should allow
firmware loading from this partition

Test: firmware is loaded succesfully
Change-Id: I7d327bc79a04d1a2dee0fd47407eb53f9d391665
Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>